### PR TITLE
rails add requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Beautiful::Log::Formatter.new(
 ## Requirements
 
 - Ruby 2.3-
+- Rails 4.x.x -
 
 ## Contribution
 


### PR DESCRIPTION
I think rails witten readme kind and also versions.

  actual
  ```
  ## Requirements
  - Ruby 2.3-
  ```

  expected
   ```
    ## Requirements
    - Ruby 2.3-
    - Rails 4.x.x -
   
   ```
